### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "minilog": "2.0.x",
     "mixu_minimal": "0.0.1",
     "mkdirp": "0.5.0",
-    "request": "2.36.0",
+    "request": "2.74.0",
     "semver": "1.0",
     "yargs": "1.3.1"
   },


### PR DESCRIPTION
npm_lazy currently has a 2 vulnerable dependency, introducing 5 different types of known vulnerabilities.

This PR fixes one vulnerable dependency and 4 different types of known vulnerabilities. 
You can see [Snyk test report](https://snyk.io/test/github/mixu/npm_lazy) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and does not pull in any other vulnerable dependencies.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

There is no automated tests in your `Package.json`,check if the upgrade does'nt make you problems.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)